### PR TITLE
Lint entrypoint.py

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,14 @@ name: PR
 on: pull_request
 
 jobs:
+  lint-entrypoint-py:
+    name: Lint entrypoint.py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: pylint
+        run: make pylint
+
   superlinter:
     name: Lint bash, docker, markdown, and yaml
     runs-on: ubuntu-latest
@@ -24,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Docker build
-        run: "docker build --pull ."
+        run: make build
 
   verify-changelog:
     name: Verify CHANGELOG is valid

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN apk add --update --no-cache \
   git \
   py3-pip
 
-RUN pip3 install gitpython PyGithub
+RUN pip3 install \
+  gitpython \
+  PyGithub \
+  pylint
 
 ENTRYPOINT ["/entrypoint.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+TAG := docker.pkg.github.com/ponylang/action-readme-version-updater/action-readme-version-updater:latest
+
+all: build
+
+build:
+	docker build --pull -t ${TAG} .
+
+pylint: build
+	docker run --entrypoint pylint --rm ${TAG} /entrypoint.py
+
+.PHONY: build pylint

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,16 +1,21 @@
 #!/usr/bin/python3
+# pylint: disable=C0103
+# pylint: disable=C0114
 
-import git,json,os,re,sys
+import os
+import re
+import sys
+import git
 from github import Github
 
-ENDC   = '\033[0m'
-ERROR  = '\033[31m'
-INFO   = '\033[34m'
+ENDC = '\033[0m'
+ERROR = '\033[31m'
+INFO = '\033[34m'
 NOTICE = '\033[33m'
 
-if not 'API_CREDENTIALS' in os.environ:
-  print(ERROR + "API_CREDENTIALS needs to be set in env. Exiting." + ENDC)
-  sys.exit(1)
+if 'API_CREDENTIALS' not in os.environ:
+    print(ERROR + "API_CREDENTIALS needs to be set in env. Exiting." + ENDC)
+    sys.exit(1)
 
 # Get repository and version names from the environment
 # version is in the form of "refs/tags/1.0.0" where the version is 1.0.0
@@ -21,7 +26,12 @@ version = re.sub('refs/tags/', '', os.environ['GITHUB_REF'])
 github = Github(os.environ['API_CREDENTIALS'])
 
 print(INFO + "Cloning repo." + ENDC)
-clone_from = "https://" + os.environ['GITHUB_ACTOR'] + ":" + os.environ['API_CREDENTIALS'] + "@github.com/" + repository
+clone_from = "https://" \
+             + os.environ['GITHUB_ACTOR'] \
+             + ":" \
+             + os.environ['API_CREDENTIALS'] \
+             + "@github.com/" \
+             + repository
 git = git.Repo.clone_from(clone_from, '.').git
 
 print(INFO + "Setting up git configuration." + ENDC)
@@ -29,7 +39,7 @@ git.config('--global', 'user.name', os.environ['INPUT_GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['INPUT_GIT_USER_EMAIL'])
 
 # what to find and what to replace it with
-find = f'{repository}@\d+\.\d+\.\d+'
+find = f'{repository}@\d+\.\d+\.\d+' # pylint: disable=W1401
 replace = f'{repository}@{version}'
 
 # open README.md and update with new version
@@ -47,15 +57,17 @@ git.commit('-m', f'Update README examples to reflect new version {version}')
 
 print(INFO + "Pushing updated README." + ENDC)
 push_failures = 0
-while(True):
-  try:
-    git.push()
-    break
-  except:
-    push_failures += 1
-    if (push_failures <= 5):
-      print(NOTICE + "Failed to push. Going to pull and try again." + ENDC)
-      git.pull()
-    else:
-      print(ERROR + "Failed to push again. Giving up." + ENDC)
-      raise
+while True:
+    try:
+        git.push()
+        break
+    except git.GitCommandError:
+        push_failures += 1
+        if push_failures <= 5:
+            print(NOTICE
+                  + "Failed to push. Going to pull and try again."
+                  + ENDC)
+            git.pull()
+        else:
+            print(ERROR + "Failed to push again. Giving up." + ENDC)
+            raise


### PR DESCRIPTION
Sets up linting of entrypoint.sh. I previously tried to do using
GitHub's superlinter, however, being able to use Python linters
with the required dependencies is a bit of a nightmare.

This update includes pylink in the same docker container that our
action normally runs in making it easy to build for both running
and for linting of the code.

Also included is a Makefile that currently allows for building
the container as well as linting it via two targets:

- build
- pylint

The Makefile is a first step towards being able to build fixed containers
on release and use those rather than rebuilding each time the action is
used for actions in various workflows. I'm planning on hosting those
released versions in GitHub packages, thus the stub "tag" in the Makefile
referencing the GitHub packages url. The name in the tag is currently unimportant
and can be ignored until such time as a push action is added to Makefile at
which point the tag name will become "real".

This commit also includes changes to entrypoint.py needed to get it to pass
the pylint linting.