### PR TITLE
Fix broken push retries

### DIFF
--- a/.release-notes/correct-repush.md
+++ b/.release-notes/correct-repush.md
@@ -1,0 +1,3 @@
+## Fix broken push retries
+
+Previously, we added a retry to a failed push where we would pull the latest changes and then push again. However, this didn't work as the wrong exception was being caught.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -62,7 +62,7 @@ while True:
     try:
         git.push()
         break
-    except git.GitCommandError:
+    except git.exc.GitCommandError:
         push_failures += 1
         if push_failures <= 5:
             print(NOTICE


### PR DESCRIPTION
Previously, we added a retry to a failed push where we would pull
the latest changes and then push again. However, this didn't work
as the wrong exception was being caught.