### PR TITLE
Rebase on pull

### DIFF
--- a/.release-notes/rebase-on-pull.md
+++ b/.release-notes/rebase-on-pull.md
@@ -1,0 +1,3 @@
+## Rebase on pull
+
+Prior to this change, this bot would sometimes create a merge commit when pushing changes if it had to pull down other changes first. We now set `--rebase` when doing pulls to avoid muddying up the history.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -69,7 +69,7 @@ while True:
             print(NOTICE
                   + "Failed to push. Going to pull and try again."
                   + ENDC)
-            git.pull()
+            git.pull('--rebase')
         else:
             print(ERROR + "Failed to push again. Giving up." + ENDC)
             raise

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -69,7 +69,7 @@ while True:
             print(NOTICE
                   + "Failed to push. Going to pull and try again."
                   + ENDC)
-            git.pull('--rebase')
+            git.pull(rebase=True)
         else:
             print(ERROR + "Failed to push again. Giving up." + ENDC)
             raise


### PR DESCRIPTION
Prior to this change, the bot would sometimes create a merge commit
when pushing changes if it had to pull down other changes first.
We now set `--rebase` when doing pulls to avoid muddying up the history.