### PR TITLE
Improve logging around multiple push attempts

### DIFF
--- a/.release-notes/improve-pull-messaging.md
+++ b/.release-notes/improve-pull-messaging.md
@@ -1,0 +1,5 @@
+## Improve logging around multiple push attempts
+
+Previously, if the bot failed to push its updates, it would create a log message for each pull that it attempted but only for the first push. This could be confusing to the user.
+
+Now each push and pull attempt will be logged.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -57,10 +57,10 @@ print(INFO + "Adding git changes." + ENDC)
 git.add('README.md')
 git.commit('-m', f'Update README examples to reflect new version {version}')
 
-print(INFO + "Pushing updated README." + ENDC)
 push_failures = 0
 while True:
     try:
+        print(INFO + "Pushing updated README." + ENDC)
         git.push()
         break
     except GitCommandError:


### PR DESCRIPTION
Previously, if the bot failed to push its updates, it would create a
log message for each pull that it attempted but only for the first
push. This could be confusing to the user.

Now each push and pull attempt will be logged.