### PR TITLE
Add support for README files that aren't README.md

### DIFF
--- a/.release-notes/dot-rst.md
+++ b/.release-notes/dot-rst.md
@@ -1,0 +1,3 @@
+## Add support for README files that aren't README.md
+
+Previous versions of the readme-version-updater-action assumed that all projects had a README named `README.md`. With this change, you can now use either `README.md` or `README.rst`.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ corral add github.com/ponylang/appdirs.git --version 0.1.0
 
 On release of said library, the version in the corral add string will be updated by this action to whatever the new version is. Note that because this action is a GitHub action, corral add instruction updating only works for add instructions that are referencing a git repo.
 
+A project's README is assumed to be named either `README.md` or `README.rst`. The first one found will be used. The action will fail if no README file is found.
+
 ## Example workflow
 
 The readme-version-updater-action should be set up as an "artefact building step" in the release-bot-action's [release.yml](https://github.com/ponylang/release-bot-action#trigger-release-announcement).

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -3,6 +3,7 @@
 # pylint: disable=C0114
 
 import os
+import os.path
 import re
 import sys
 import git
@@ -49,9 +50,26 @@ subs = [
     )
 ]
 
-# open README.md and update with new version
-print(INFO + "Updating versions in README.md to " + version + ENDC)
-readme = open("README.md", "r+")
+# find the README
+readme_file_options = [
+    "README.md",
+    "README.rst"
+]
+
+readme_file = ""
+for rfo in readme_file_options:
+    if os.path.isfile(rfo):
+        readme_file = rfo
+        break
+
+
+if not readme_file:
+    print(ERROR + "Unable to find README. Exiting." + ENDC)
+    sys.exit(1)
+
+# open README and update with new version
+print(INFO + "Updating versions in " + readme_file + " to " + version + ENDC)
+readme = open(readme_file, "r+")
 text = readme.read()
 for sub in subs:
     (find, replace) = sub
@@ -61,8 +79,9 @@ readme.write(text)
 readme.close()
 
 print(INFO + "Adding git changes." + ENDC)
-git.add('README.md')
-git.commit('-m', f'Update README examples to reflect new version {version}')
+git.add(readme_file)
+git.commit('-m',
+    f'Update {readme_file} examples to reflect new version {version}')
 
 push_failures = 0
 while True:


### PR DESCRIPTION
Previous versions of the readme-version-updater-action assumed that
all projects had a README named `README.md`. With this change, you
can now use either `README.md` or `README.rst`.

Adding additional README filenames would be a matter of adding additional
items to a the `readme_file_options` list.